### PR TITLE
Add chatroom creation dialog

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -37,10 +37,10 @@ function MessageInput({ onSend, user }) {
 function ChatroomList({ rooms, selectedId, onSelect, onCreate }) {
   return (
     <div className="chatrooms">
-      <div className="chatrooms-header">
-        <span>Chatrooms</span>
-        <button onClick={onCreate}>+</button>
-      </div>
+      <div className="chatrooms-header">Chatrooms</div>
+      <button className="create-chatroom-btn" onClick={onCreate}>
+        Create Chatroom
+      </button>
       {rooms.map((r) => (
         <div
           key={r.id}
@@ -58,6 +58,8 @@ function ChatApp({ user }) {
   const [rooms, setRooms] = useState([]);
   const [current, setCurrent] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newRoomName, setNewRoomName] = useState('');
 
   const loadRooms = () => {
     fetch('/chatrooms?user=' + encodeURIComponent(user))
@@ -91,19 +93,42 @@ function ChatApp({ user }) {
   };
 
   const createRoom = () => {
-    const name = prompt('Chatroom name');
-    if (!name) return;
+    setShowCreate(true);
+  };
+
+  const submitCreateRoom = () => {
+    if (!newRoomName) return;
     fetch('/chatrooms', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, user }),
+      body: JSON.stringify({ name: newRoomName, user }),
     })
       .then((r) => r.json())
-      .then(() => loadRooms());
+      .then(() => {
+        setShowCreate(false);
+        setNewRoomName('');
+        loadRooms();
+      });
   };
 
   return (
     <div className="chat-app">
+      {showCreate && (
+        <div className="dialog-backdrop">
+          <div className="dialog">
+            <h2>Create Chatroom</h2>
+            <input
+              placeholder="Chatroom Name"
+              value={newRoomName}
+              onChange={(e) => setNewRoomName(e.target.value)}
+            />
+            <div>
+              <button onClick={submitCreateRoom}>Create</button>
+              <button onClick={() => setShowCreate(false)}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
       <ChatroomList
         rooms={rooms}
         selectedId={current ? current.id : null}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -60,3 +60,26 @@ body {
 .register-form input {
   margin-bottom: 10px;
 }
+
+.create-chatroom-btn {
+  width: 100%;
+  margin: 5px 0 10px 0;
+}
+
+.dialog-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dialog {
+  background: #2f3136;
+  padding: 20px;
+  border-radius: 5px;
+}


### PR DESCRIPTION
## Summary
- allow creating chatrooms from a dialog instead of a browser prompt
- style modal and button

## Testing
- `npm run --prefix frontend` *(fails: Unknown env config 'http-proxy')*

------
https://chatgpt.com/codex/tasks/task_e_684b23bb80e883318ace9d8890848b9e