### PR TITLE
Add chatroom member list with online status

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -54,10 +54,24 @@ function ChatroomList({ rooms, selectedId, onSelect, onCreate }) {
   );
 }
 
+function MemberList({ members }) {
+  return (
+    <div className="members">
+      <div className="chatrooms-header">Members</div>
+      {members.map((m) => (
+        <div key={m.username} className="member" style={{ opacity: m.online ? 1 : 0.5 }}>
+          {m.username}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function ChatApp({ user }) {
   const [rooms, setRooms] = useState([]);
   const [current, setCurrent] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [members, setMembers] = useState([]);
   const [showCreate, setShowCreate] = useState(false);
   const [newRoomName, setNewRoomName] = useState('');
 
@@ -77,6 +91,9 @@ function ChatApp({ user }) {
     fetch('/messages?chatroom_id=' + current.id)
       .then((r) => r.json())
       .then((data) => setMessages(data));
+    fetch('/members?chatroom_id=' + current.id)
+      .then((r) => r.json())
+      .then((data) => setMembers(data));
   };
 
   useEffect(loadMessages, [current]);
@@ -140,6 +157,7 @@ function ChatApp({ user }) {
         {current && <MessageList messages={messages} />}
         {current && <MessageInput onSend={sendMessage} user={user} />}
       </div>
+      <MemberList members={members} />
     </div>
   );
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -8,7 +8,7 @@ body {
 
 .chat-app {
   display: flex;
-  width: 600px;
+  width: 800px;
   margin: 20px auto;
   background: #2f3136;
   padding: 10px;
@@ -18,6 +18,15 @@ body {
 .chatrooms {
   width: 150px;
   margin-right: 10px;
+}
+
+.members {
+  width: 150px;
+  margin-left: 10px;
+}
+
+.member {
+  padding: 5px;
 }
 
 .chatroom {


### PR DESCRIPTION
## Summary
- display chatroom members with online/offline styling
- show member list in UI and fetch from new `/members` endpoint
- track `online` status on users
- seed 10 test users in the `test` chatroom
- adjust layout width and add styles for member column

## Testing
- `ruby -c backend/server.rb`

------
https://chatgpt.com/codex/tasks/task_e_684b26f4ff9c833190cd08216fac8bc8