### PR TITLE
Add user banner with edit profile dialog

### DIFF
--- a/frontend/components/ChatApp.js
+++ b/frontend/components/ChatApp.js
@@ -4,6 +4,7 @@ const ChatApp = ({ user }) => {
   const [messages, setMessages] = React.useState([]);
   const [members, setMembers] = React.useState([]);
   const [showCreate, setShowCreate] = React.useState(false);
+  const [showEdit, setShowEdit] = React.useState(false);
   const [newRoomName, setNewRoomName] = React.useState('');
 
   const loadRooms = async () => {
@@ -58,12 +59,25 @@ const ChatApp = ({ user }) => {
           </div>
         </div>
       )}
-      <ChatroomList
-        rooms={rooms}
-        selectedId={current ? current.id : null}
-        onSelect={setCurrent}
-        onCreate={createRoom}
-      />
+      {showEdit && (
+        <div className="dialog-backdrop">
+          <div className="dialog">
+            <h2>Edit Profile</h2>
+            <div>
+              <button onClick={() => setShowEdit(false)}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+      <div className="left-column">
+        <ChatroomList
+          rooms={rooms}
+          selectedId={current ? current.id : null}
+          onSelect={setCurrent}
+          onCreate={createRoom}
+        />
+        <UserBanner user={user} onEdit={() => setShowEdit(true)} />
+      </div>
       <div className="chat-window">
         <h1>{current ? current.name : 'Select a chatroom'}</h1>
         {current && <MessageList messages={messages} />}

--- a/frontend/components/UserBanner.js
+++ b/frontend/components/UserBanner.js
@@ -1,0 +1,11 @@
+const UserBanner = ({ user, onEdit }) => {
+  return (
+    <div className="user-banner">
+      <div className="avatar-placeholder" />
+      <span className="user-banner-name">{user}</span>
+      <button className="edit-profile-icon" onClick={onEdit}>
+        &#9881;
+      </button>
+    </div>
+  );
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,7 @@
   <script type="text/babel" src="components/MessageInput.js"></script>
   <script type="text/babel" src="components/ChatroomList.js"></script>
   <script type="text/babel" src="components/MemberList.js"></script>
+  <script type="text/babel" src="components/UserBanner.js"></script>
   <script type="text/babel" src="components/ChatApp.js"></script>
   <script type="text/babel" src="components/LoginForm.js"></script>
   <script type="text/babel" src="components/RegisterForm.js"></script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -17,7 +17,7 @@ body {
 
 .chatrooms {
   width: 150px;
-  margin-right: 10px;
+  margin-right: 0;
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
@@ -142,4 +142,41 @@ body {
   background: #2f3136;
   padding: 20px;
   border-radius: 5px;
+}
+
+.left-column {
+  width: 150px;
+  margin-right: 10px;
+  display: flex;
+  flex-direction: column;
+}
+
+.user-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #202225;
+  border-radius: 5px;
+  padding: 10px;
+  margin-top: 10px;
+}
+
+.avatar-placeholder {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #72767d;
+  margin-right: 5px;
+}
+
+.edit-profile-icon {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- add UserBanner component that shows the current user and an edit button
- allow ChatApp to open an Edit Profile dialog
- restructure left side of chat app to include user banner
- update styles for the new banner and left column layout
- include UserBanner script in index.html

## Testing
- `npm test --prefix frontend` *(fails: missing script)*
- `ruby -c backend/server.rb`


------
https://chatgpt.com/codex/tasks/task_e_684b9e27c16883318d2b5fabf9e26cd8