### PR TITLE
Adjust chat layout

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -21,6 +21,7 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .members {
@@ -29,6 +30,7 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .member {
@@ -49,6 +51,7 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .messages {
@@ -142,6 +145,7 @@ body {
   background: #2f3136;
   padding: 20px;
   border-radius: 5px;
+  width: 450px;
 }
 
 .left-column {
@@ -158,7 +162,7 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
-  margin-top: 10px;
+  margin-top: auto;
 }
 
 .avatar-placeholder {


### PR DESCRIPTION
## Summary
- add subtle box shadows so columns appear to float
- enlarge dialog boxes
- push user banner to the bottom of the left column

## Testing
- `ruby -c backend/server.rb`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c200d71148331b207298ad3e79511