### PR TITLE
Revert style layout changes

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -158,7 +158,7 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
-  margin-top: 10px;
+  margin-top: auto;
 }
 
 .avatar-placeholder {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -21,7 +21,6 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .members {
@@ -30,7 +29,6 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .member {
@@ -51,7 +49,6 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .messages {
@@ -145,7 +142,6 @@ body {
   background: #2f3136;
   padding: 20px;
   border-radius: 5px;
-  width: 450px;
 }
 
 .left-column {
@@ -162,7 +158,7 @@ body {
   border: 1px solid #202225;
   border-radius: 5px;
   padding: 10px;
-  margin-top: auto;
+  margin-top: 10px;
 }
 
 .avatar-placeholder {


### PR DESCRIPTION
## Summary
- revert layout adjustments in `frontend/style.css`

## Testing
- `npm --prefix frontend test` *(fails: Missing script)*
- `bundle exec rake test` *(fails: could not find gem 'webrick')*

------
https://chatgpt.com/codex/tasks/task_e_684c2b0bd240833186034f05578a0931